### PR TITLE
Refactor background worker into modules

### DIFF
--- a/alarms.js
+++ b/alarms.js
@@ -1,0 +1,85 @@
+import { config } from "./config.js";
+import { sendMessageToUrl, WHATSAPP_URL } from "./tabs.js";
+
+function getStorageValue(key) {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get([key], function(data) {
+      data[key] === void 0 ? reject() : resolve(data[key]);
+    });
+  });
+}
+
+function hasNotificationTimedOut(dateString) {
+  const targetDate = new Date(dateString);
+  const currentDate = /* @__PURE__ */ new Date();
+  const diff = targetDate.getTime() - currentDate.getTime();
+  return diff <= 12e4 || diff < 0;
+}
+
+async function updateNotifications() {
+  const notifications = await getStorageValue("notifications");
+  const updatedNotifications = [];
+  const dispatchableNotifications = [];
+  let unreadCount = 0;
+  for (let notification of notifications)
+    !notification.timeOut && hasNotificationTimedOut(`${notification.date}T${notification.time}`) && (notification.timeOut = !0, dispatchableNotifications.push(notification)), notification.timeOut && !notification.read && unreadCount++, updatedNotifications.push(notification);
+  sendMessageToUrl(WHATSAPP_URL, "Update_Notificação", {
+    update: updatedNotifications,
+    dispart: dispatchableNotifications,
+    tam: unreadCount
+  });
+}
+
+async function fetchDomSelectorVersion() {
+  try {
+    const response = await fetch(config.domSelector);
+    const payload = await response.json();
+    typeof payload == "object" && typeof payload.version == "string" && sendMessageToUrl(WHATSAPP_URL, "Update_DomSelector", { version: payload.version });
+  } catch (error) {
+    console.error("Error ao tentar Capturar o Dom Selector virtual", error);
+  }
+}
+
+export function ensureRecurringAlarms() {
+  chrome.alarms.get("One_Minute", (alarm) => {
+    alarm || chrome.alarms.create("One_Minute", { periodInMinutes: 1 });
+  });
+  chrome.alarms.get("Five_Minutes", (alarm) => {
+    alarm || chrome.alarms.create("Five_Minutes", { periodInMinutes: 5 });
+  });
+  chrome.alarms.get("Ten_Minutes", (alarm) => {
+    alarm || chrome.alarms.create("Ten_Minutes", { periodInMinutes: 10 });
+  });
+  chrome.alarms.get("Thirty_Minutes", (alarm) => {
+    alarm || chrome.alarms.create("Thirty_Minutes", { periodInMinutes: 30 });
+  });
+}
+
+function onAlarmTriggered(alarm) {
+  switch (alarm.name) {
+    case "One_Minute":
+      sendMessageToUrl(WHATSAPP_URL, "Update_Agendamento", {});
+      sendMessageToUrl(WHATSAPP_URL, "Update_Status", {});
+      sendMessageToUrl(WHATSAPP_URL, "Update_BackupAutomatico", {});
+      sendMessageToUrl(WHATSAPP_URL, "Update_MeetAoVivo", {});
+      updateNotifications();
+      break;
+    case "Five_Minutes":
+      sendMessageToUrl(WHATSAPP_URL, "license_update", {});
+      sendMessageToUrl(WHATSAPP_URL, "dispatch_timing_follow", {});
+      break;
+    case "Ten_Minutes":
+      fetchDomSelectorVersion();
+      break;
+    case "Thirty_Minutes":
+      sendMessageToUrl(WHATSAPP_URL, "Remote-Notificacao", {});
+      break;
+    case "keepAwake":
+      chrome.runtime.getPlatformInfo();
+      break;
+  }
+}
+
+export function registerAlarmHandlers() {
+  chrome.alarms.onAlarm.addListener(onAlarmTriggered);
+}

--- a/background.js
+++ b/background.js
@@ -1,103 +1,17 @@
-function n(e, t, o) {
-  chrome.tabs.query({ url: e }, function(s) {
-    s.length > 0 && s.forEach((a) => {
-      chrome.tabs.sendMessage(a.id, { action: t, dados: o });
-    });
-  });
+import { ensureRecurringAlarms, registerAlarmHandlers } from "./alarms.js";
+import { ensureWhatsAppStatusListeners, openExtensionTab, openOrReloadWhatsAppTab } from "./tabs.js";
+
+function getTomorrowDate() {
+  const tomorrow = /* @__PURE__ */ new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const year = tomorrow.getFullYear();
+  const month = String(tomorrow.getMonth() + 1).padStart(2, "0");
+  const day = String(tomorrow.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
-async function h(e) {
-  return new Promise((t, o) => {
-    chrome.storage.local.get([e], function(s) {
-      s[e] === void 0 ? o() : t(s[e]);
-    });
-  });
-}
-function d(e) {
-  const t = new Date(e), o = /* @__PURE__ */ new Date(), s = t.getTime() - o.getTime();
-  return s <= 12e4 || s < 0;
-}
-async function f() {
-  const e = await h("notifications"), t = [], o = [];
-  let s = 0;
-  for (let a of e)
-    !a.timeOut && d(`${a.date}T${a.time}`) && (a.timeOut = !0, o.push(a)), a.timeOut && !a.read && s++, t.push(a);
-  n("https://web.whatsapp.com/*", "Update_Notificação", { update: t, dispart: o, tam: s });
-}
-const w = {
-  // Nome Da WL Ativa
-  name: "BotStar Plus",
-  // Versão de build
-  version: "7.4.2",
-  // Chave de criptografia
-  cript_key: "ffce211a-7b07-4d91-ba5d-c40bb4034a83",
-  //Url do backend Principal
-  backend: "https://backend.lotsofwms.in/",
-  // Url do backend de funções auxiliares
-  backend_utils: "https://backend-utils.wascript.com.br/",
-  // WebSockets
-  webSocket: {
-    "multi-atendimento": "https://multi-atendimento.wascript.com.br",
-    "api-whatsapp": "https://api-whatsapp.wascript.com.br"
-  },
-  // Url do painel de gestão
-  painel_Gestor: "https://wa.link/73606u",
-  // Url do audio transcriber
-  audio_transcriber: "https://audio-transcriber.wascript.com.br/transcription",
-  // Selector de elementos DOM
-  domSelector: "https://backend.lotsofwms.in/api/common/v2/domselector.php",
-  // Limite de mídia no Resposta Rápida
-  midiaLimit: 50
-};
-async function b() {
-  try {
-    const t = await (await fetch(w.domSelector)).json();
-    typeof t == "object" && typeof t.version == "string" && n("https://web.whatsapp.com/*", "Update_DomSelector", { version: t.version });
-  } catch (e) {
-    console.error("Error ao tentar Capturar o Dom Selector virtual", e);
-  }
-}
-function c() {
-  chrome.alarms.get("One_Minute", (e) => {
-    e || chrome.alarms.create("One_Minute", { periodInMinutes: 1 });
-  }), chrome.alarms.get("Five_Minutes", (e) => {
-    e || chrome.alarms.create("Five_Minutes", { periodInMinutes: 5 });
-  }), chrome.alarms.get("Ten_Minutes", (e) => {
-    e || chrome.alarms.create("Ten_Minutes", { periodInMinutes: 10 });
-  }), chrome.alarms.get("Thirty_Minutes", (e) => {
-    e || chrome.alarms.create("Thirty_Minutes", { periodInMinutes: 30 });
-  });
-}
-chrome.alarms.onAlarm.addListener((e) => {
-  switch (e.name) {
-    // 1 Minuto
-    case "One_Minute":
-      n("https://web.whatsapp.com/*", "Update_Agendamento", {}), n("https://web.whatsapp.com/*", "Update_Status", {}), n("https://web.whatsapp.com/*", "Update_BackupAutomatico", {}), n("https://web.whatsapp.com/*", "Update_MeetAoVivo", {}), f();
-      break;
-    // 5 Minutos
-    case "Five_Minutes":
-      n("https://web.whatsapp.com/*", "license_update", {}), n("https://web.whatsapp.com/*", "dispatch_timing_follow", {});
-      break;
-    // 10 Minutos
-    case "Ten_Minutes":
-      b();
-      break;
-    // 30 Minutos
-    case "Thirty_Minutes":
-      n("https://web.whatsapp.com/*", "Remote-Notificacao", {});
-      break;
-    // Alarme de manter o sistema ativo
-    case "keepAwake":
-      chrome.runtime.getPlatformInfo();
-      break;
-  }
-});
-const g = () => {
-  const e = /* @__PURE__ */ new Date();
-  e.setDate(e.getDate() + 1);
-  const t = e.getFullYear(), o = String(e.getMonth() + 1).padStart(2, "0"), s = String(e.getDate()).padStart(2, "0");
-  return `${t}-${o}-${s}`;
-}, M = {
-  date: g(),
+
+const DEFAULT_BACKUP_CONFIGURATION = {
+  date: getTomorrowDate(),
   items: [
     "respostasRapidas",
     "respostasRapidasAcao",
@@ -128,106 +42,92 @@ const g = () => {
   recurrency: "diario",
   time: "10:30"
 };
-async function A() {
-  chrome.storage.local.get(null, (e) => {
+
+function initializeStorageDefaults() {
+  chrome.storage.local.get(null, (storedValues) => {
     chrome.storage.local.set({
-      agendamentos: e.agendamentos || [],
-      agendamentosNaoDisparados: e.agendamentosNaoDisparados || [],
-      sendAfterWhatsAppOpens: e.sendAfterWhatsAppOpens || !1,
-      notifications: e.notifications || [],
-      userTabs: e.userTabs || [],
-      contatos: e.contatos || [],
-      notes: e.notes || [],
-      agendaMsg: e.agendaMsg || [],
-      perfil: e.perfil || [],
-      categoria: e.categoria || [],
-      initSystem: e.initSystem || !1,
-      backupAutomatico: e.backupAutomatico || M,
-      crm: e.crm || [],
-      fluxo: e.fluxo || { workflows: [], currentWorkflow: null },
-      fluxoFiles: e.fluxoFiles || [],
-      agrupamentos: e.agrupamentos || [],
-      relatorio: e.relatorio || [],
-      encomendas: e.encomendas || [],
-      autoatendimento: e.autoatendimento || [],
-      FollowUp: e.FollowUp || [],
-      webhook: e.webhook || [],
-      IA: e.IA || { activeIA: null, keyGemini: "", keyGPT: "" },
-      status: e.status || [],
-      pinChat: e.pinChat || [],
-      atendimento: e.atendimento || void 0,
-      whatsApi: e.whatsApi || { active: !1, token: "", userID: "" },
-      initDate: e.initDate || !1,
-      //Armazena a data em que o plugin foi instalado para validar a utilização de algumas funções do usuário free
-      modalLead: e.modalLead || {},
-      // Respostas Rapidas OLD
-      guardaMsg: e.guardaMsg || [],
-      medias: e.medias || [],
-      // Respostas Rapidas New
-      respostasRapidas: e.respostasRapidas || [],
-      respostasRapidasAcao: e.respostasRapidasAcao || []
+      agendamentos: storedValues.agendamentos || [],
+      agendamentosNaoDisparados: storedValues.agendamentosNaoDisparados || [],
+      sendAfterWhatsAppOpens: storedValues.sendAfterWhatsAppOpens || !1,
+      notifications: storedValues.notifications || [],
+      userTabs: storedValues.userTabs || [],
+      contatos: storedValues.contatos || [],
+      notes: storedValues.notes || [],
+      agendaMsg: storedValues.agendaMsg || [],
+      perfil: storedValues.perfil || [],
+      categoria: storedValues.categoria || [],
+      initSystem: storedValues.initSystem || !1,
+      backupAutomatico: storedValues.backupAutomatico || DEFAULT_BACKUP_CONFIGURATION,
+      crm: storedValues.crm || [],
+      fluxo: storedValues.fluxo || { workflows: [], currentWorkflow: null },
+      fluxoFiles: storedValues.fluxoFiles || [],
+      agrupamentos: storedValues.agrupamentos || [],
+      relatorio: storedValues.relatorio || [],
+      encomendas: storedValues.encomendas || [],
+      autoatendimento: storedValues.autoatendimento || [],
+      FollowUp: storedValues.FollowUp || [],
+      webhook: storedValues.webhook || [],
+      IA: storedValues.IA || { activeIA: null, keyGemini: "", keyGPT: "" },
+      status: storedValues.status || [],
+      pinChat: storedValues.pinChat || [],
+      atendimento: storedValues.atendimento || void 0,
+      whatsApi: storedValues.whatsApi || { active: !1, token: "", userID: "" },
+      initDate: storedValues.initDate || !1,
+      modalLead: storedValues.modalLead || {},
+      guardaMsg: storedValues.guardaMsg || [],
+      medias: storedValues.medias || [],
+      respostasRapidas: storedValues.respostasRapidas || [],
+      respostasRapidasAcao: storedValues.respostasRapidasAcao || []
     });
   });
 }
-function u() {
-  chrome.tabs.query({ url: "https://web.whatsapp.com/*" }, function(e) {
-    e.length > 0 && e[0].id !== void 0 ? chrome.tabs.reload(e[0].id) : chrome.tabs.create({ url: "https://web.whatsapp.com" });
-  });
-}
-function k() {
+
+function configureUninstallRedirect() {
   chrome.runtime.setUninstallURL(`https://backend.lotsofwms.in/api/common/v2/urls/uninstall.php?id=683f11a52f516`);
 }
-function _(e) {
-  e.reason === "install" && fetch(`https://backend.lotsofwms.in/api/common/v2/urls/install.php?id=683f11a52f516`).then((t) => {
-    if (!t.ok)
-      throw new Error("Erro na requisição: " + t.status);
-    return t.json();
-  }).then((t) => {
-    t.success && chrome.tabs.create({ url: t.url });
-  }).catch((t) => {
-    console.error("Erro ao fazer a requisição:", t);
-  });
+
+function handleInstallEvent(details) {
+  if (details.reason === "install")
+    fetch(`https://backend.lotsofwms.in/api/common/v2/urls/install.php?id=683f11a52f516`).then((response) => {
+      if (!response.ok)
+        throw new Error("Erro na requisição: " + response.status);
+      return response.json();
+    }).then((payload) => {
+      payload.success && chrome.tabs.create({ url: payload.url });
+    }).catch((error) => {
+      console.error("Erro ao fazer a requisição:", error);
+    });
 }
-function i(e) {
-  const t = chrome.runtime.getURL(e + "/src/index.html");
-  chrome.tabs.query({ url: t }, function(o) {
-    o.length > 0 && o.forEach((s) => {
-      s.id !== void 0 && chrome.tabs.remove(s.id);
-    }), chrome.tabs.create({ url: t });
-  });
-}
-const r = /* @__PURE__ */ new Map(), p = (e, t, o) => {
-  o.url && r.set(e, o.url);
-}, l = (e) => {
-  const t = r.get(e);
-  r.delete(e), t && t.includes("https://web.whatsapp") && chrome.runtime.sendMessage({ action: "whatsIsClosed" });
-}, m = () => {
-  try {
-    chrome.tabs.onUpdated.removeListener(p), chrome.tabs.onRemoved.removeListener(l);
-  } catch (e) {
-    console.error("erro ao remover os ouvintes do WhatsIsOpen", e);
-  } finally {
-    chrome.tabs.onUpdated.addListener(p), chrome.tabs.onRemoved.addListener(l);
-  }
-};
-c();
-m();
+
+registerAlarmHandlers();
+ensureRecurringAlarms();
+ensureWhatsAppStatusListeners();
+
 chrome.action.onClicked.addListener(() => {
-  c(), m(), u();
+  ensureRecurringAlarms();
+  ensureWhatsAppStatusListeners();
+  openOrReloadWhatsAppTab();
 });
-chrome.runtime.onInstalled.addListener(async function(e) {
-  _(e), u(), c(), A(), m(), k();
+
+chrome.runtime.onInstalled.addListener(async function(details) {
+  handleInstallEvent(details);
+  openOrReloadWhatsAppTab();
+  ensureRecurringAlarms();
+  initializeStorageDefaults();
+  ensureWhatsAppStatusListeners();
+  configureUninstallRedirect();
 });
-chrome.runtime.onMessage.addListener((e, t, o) => {
-  switch (e.message) {
+
+chrome.runtime.onMessage.addListener((message) => {
+  switch (message.message) {
     case "CRM":
-      i("crm");
+      openExtensionTab("crm");
       break;
     case "FLOW":
-      i("fluxo");
+      openExtensionTab("fluxo");
       break;
     case "funnil":
-      i("funnil");
+      openExtensionTab("funnil");
       break;
   }
 });

--- a/config.js
+++ b/config.js
@@ -1,0 +1,25 @@
+export const config = {
+  // Nome Da WL Ativa
+  name: "BotStar Plus",
+  // Versão de build
+  version: "7.4.2",
+  // Chave de criptografia
+  cript_key: "ffce211a-7b07-4d91-ba5d-c40bb4034a83",
+  //Url do backend Principal
+  backend: "https://backend.lotsofwms.in/",
+  // Url do backend de funções auxiliares
+  backend_utils: "https://backend-utils.wascript.com.br/",
+  // WebSockets
+  webSocket: {
+    "multi-atendimento": "https://multi-atendimento.wascript.com.br",
+    "api-whatsapp": "https://api-whatsapp.wascript.com.br"
+  },
+  // Url do painel de gestão
+  painel_Gestor: "https://wa.link/73606u",
+  // Url do audio transcriber
+  audio_transcriber: "https://audio-transcriber.wascript.com.br/transcription",
+  // Selector de elementos DOM
+  domSelector: "https://backend.lotsofwms.in/api/common/v2/domselector.php",
+  // Limite de mídia no Resposta Rápida
+  midiaLimit: 50
+};

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "version": "7.4.2",
   "description": "Gerencie leads, mensagens e vendas direto do WhatsApp com praticidade e agilidade.",
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_icon": "label/icons/icon.png"

--- a/tabs.js
+++ b/tabs.js
@@ -1,0 +1,52 @@
+const WHATSAPP_URL = "https://web.whatsapp.com/*";
+const whatsappTabs = /* @__PURE__ */ new Map();
+
+export function sendMessageToUrl(url, action, dados) {
+  chrome.tabs.query({ url }, function(tabs) {
+    tabs.length > 0 && tabs.forEach((tab) => {
+      chrome.tabs.sendMessage(tab.id, { action, dados });
+    });
+  });
+}
+
+export function openOrReloadWhatsAppTab() {
+  chrome.tabs.query({ url: WHATSAPP_URL }, function(tabs) {
+    tabs.length > 0 && tabs[0].id !== void 0
+      ? chrome.tabs.reload(tabs[0].id)
+      : chrome.tabs.create({ url: "https://web.whatsapp.com" });
+  });
+}
+
+export function openExtensionTab(featureFolder) {
+  const url = chrome.runtime.getURL(`${featureFolder}/src/index.html`);
+  chrome.tabs.query({ url }, function(tabs) {
+    tabs.length > 0 && tabs.forEach((tab) => {
+      tab.id !== void 0 && chrome.tabs.remove(tab.id);
+    });
+    chrome.tabs.create({ url });
+  });
+}
+
+function handleWhatsAppTabUpdated(tabId, _changeInfo, tab) {
+  tab.url && whatsappTabs.set(tabId, tab.url);
+}
+
+function handleWhatsAppTabRemoved(tabId) {
+  const url = whatsappTabs.get(tabId);
+  whatsappTabs.delete(tabId);
+  url && url.includes("https://web.whatsapp") && chrome.runtime.sendMessage({ action: "whatsIsClosed" });
+}
+
+export function ensureWhatsAppStatusListeners() {
+  try {
+    chrome.tabs.onUpdated.removeListener(handleWhatsAppTabUpdated);
+    chrome.tabs.onRemoved.removeListener(handleWhatsAppTabRemoved);
+  } catch (error) {
+    console.error("erro ao remover os ouvintes do WhatsIsOpen", error);
+  } finally {
+    chrome.tabs.onUpdated.addListener(handleWhatsAppTabUpdated);
+    chrome.tabs.onRemoved.addListener(handleWhatsAppTabRemoved);
+  }
+}
+
+export { WHATSAPP_URL };


### PR DESCRIPTION
## Summary
- extract the background configuration object into a dedicated config module
- split alarm handling logic and tab/message utilities into alarms.js and tabs.js modules
- update the background service worker to import the new modules and mark it as an ES module in the manifest

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f5db198c832f85f53c49aa630be0